### PR TITLE
Bump iOS SDK to version 0.1.55

### DIFF
--- a/FunnelConnect.podspec
+++ b/FunnelConnect.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |spec|
-    spec.name                     = 'FunnelConnect'
-    spec.version                  = ENV['LIB_VERSION'] || '0.1.14' #fallback to major version
-    spec.summary                  = 'FunnelConnect for iOS'
-    spec.homepage                 = 'https://github.com/Teavaro/FunnelConnect-iOS-SDK'
-    spec.source                   = { :git=> 'https://github.com/Teavaro/FunnelConnect-iOS-SDK.git', :tag => spec.version }
-    spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    spec.authors                  = { 'FunnelConnect' => 'ahmad.mahmoud@teavaro.org' }
-    spec.license                  = 'Commercial'
-    spec.vendored_frameworks      = 'FunnelConnect.xcframework'
-    spec.libraries                = 'c++'
-    spec.ios.deployment_target    = '12'
+  spec.name                     = 'FunnelConnect'
+  spec.version                  = '0.1.55'
+  spec.summary                  = 'FunnelConnect iOS SDK'
+  spec.homepage                 = 'https://github.com/Teavaro/ios-sdk'
+  spec.license                  = 'Commercial'
+  spec.author                   = { 'Teavaro' => 'support@teavaro.com' }
+  spec.platform                 = :ios, '12'
+  spec.source                   = { :http => 'https://github.com/Teavaro/ios-sdk/releases/download/0.1.55/FunnelConnect-0.1.55.zip' }
+  spec.ios.deployment_target    = '12'
+  spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.libraries                = 'c++'
+  spec.vendored_frameworks      = 'FunnelConnect.xcframework'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "FunnelConnect",
-            path: "./FunnelConnect.xcframework"
-        ),
-    ]
+            url: "https://github.com/Teavaro/ios-sdk/releases/download/0.1.55/FunnelConnect-0.1.55.zip",
+            checksum: "675d3a4fe54d5a7bb850ff057cf269e5e18dd32b4740061d37f0a216e5ee7c2b"
+        )
+    ] 
 )


### PR DESCRIPTION
Automated update for:
- `FunnelConnect.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.1.55`.