### PR TITLE
Bump iOS SDK to version 0.1.56

### DIFF
--- a/FunnelConnect.podspec
+++ b/FunnelConnect.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name                     = 'FunnelConnect'
-  spec.version                  = '0.1.55'
+  spec.version                  = '0.1.56'
   spec.summary                  = 'FunnelConnect iOS SDK'
   spec.homepage                 = 'https://github.com/Teavaro/ios-sdk'
   spec.license                  = 'Commercial'
   spec.author                   = { 'Teavaro' => 'support@teavaro.com' }
   spec.platform                 = :ios, '12'
-  spec.source                   = { :http => 'https://github.com/Teavaro/ios-sdk/releases/download/0.1.55/FunnelConnect-0.1.55.zip' }
+  spec.source                   = { :http => 'https://github.com/Teavaro/ios-sdk/releases/download/0.1.56/FunnelConnect-0.1.56.zip' }
   spec.ios.deployment_target    = '12'
   spec.pod_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   spec.user_target_xcconfig     = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "FunnelConnect",
-            url: "https://github.com/Teavaro/ios-sdk/releases/download/0.1.55/FunnelConnect-0.1.55.zip",
-            checksum: "675d3a4fe54d5a7bb850ff057cf269e5e18dd32b4740061d37f0a216e5ee7c2b"
+            url: "https://github.com/Teavaro/ios-sdk/releases/download/0.1.56/FunnelConnect-0.1.56.zip",
+            checksum: "202cb19c1aae1734183e1ae9b0aea5b3f1b8838da99f588e95ec7055921c9784"
         )
     ] 
 )


### PR DESCRIPTION
Automated update for:
- `FunnelConnect.podspec`
- `Package.swift`

This PR bumps the iOS SDK to version `0.1.56`.